### PR TITLE
Added SeedPRNG

### DIFF
--- a/scripts/license_checker.sh
+++ b/scripts/license_checker.sh
@@ -19,7 +19,6 @@
 banner_file=$(mktemp)
 
 cat <<EOF > $banner_file
-Copyright (C) 2019 Zilliqa
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -75,8 +74,8 @@ do
     filename=$(basename $file)
     ext="${filename##*.}"
     case "$ext" in
-        cpp|hpp|tpp|h|c) check_license $file 1 3 ;;
-        py|sh) check_license $file 1 2 ;;
+        cpp|hpp|tpp|h|c) check_license $file 2 3 ;;
+        py|sh) check_license $file 2 2 ;;
         *) echo unsupported format;;
     esac
 done

--- a/src/libSchnorr/src/CMakeLists.txt
+++ b/src/libSchnorr/src/CMakeLists.txt
@@ -10,7 +10,8 @@ add_library (Schnorr SHARED
 	MultiSig_Challenge.cpp
 	MultiSig_Response.cpp
 	BIGNUMSerialize.cpp
-	ECPOINTSerialize.cpp)
+	ECPOINTSerialize.cpp
+	SeedPRNG.cpp)
 
 if("${OPENSSL_VERSION_MAJOR}.${OPENSSL_VERSION_MINOR}" VERSION_LESS "1.1")
 	target_sources (Schnorr PRIVATE generate_dsa_nonce.c)

--- a/src/libSchnorr/src/SchnorrInternal.h
+++ b/src/libSchnorr/src/SchnorrInternal.h
@@ -86,4 +86,6 @@ static bool SerializableCryptoToHexStr(const T& input, std::string& str) {
 const uint8_t SECOND_DOMAIN_SEPARATED_HASH_FUNCTION_BYTE = 0x01;
 const uint8_t THIRD_DOMAIN_SEPARATED_HASH_FUNCTION_BYTE = 0x11;
 
+bool SeedPRNG();
+
 #endif  // ZILLIQA_SRC_LIBSCHNORR_SRC_SCHNORRINTERNAL_H_

--- a/src/libSchnorr/src/Schnorr_PrivKey.cpp
+++ b/src/libSchnorr/src/Schnorr_PrivKey.cpp
@@ -36,6 +36,11 @@ PrivKey::PrivKey() : m_d(BN_new(), BN_clear_free) {
     throw std::bad_alloc();
   }
 
+  if (!SeedPRNG()) {
+    // PRNG seeding failed
+    return;
+  }
+
   // kpriv->d should be in [1,...,order-1]
   do {
     if (!BN_rand_range(m_d.get(), Schnorr::GetCurveOrder())) {

--- a/src/libSchnorr/src/SeedPRNG.cpp
+++ b/src/libSchnorr/src/SeedPRNG.cpp
@@ -16,11 +16,13 @@
  */
 
 #include <openssl/rand.h>
+#include <iostream>
 #include "SchnorrInternal.h"
 
 bool SeedPRNG() {
   unsigned int attempt = 0;
   while ((RAND_status() == 0) && (attempt++ < 10)) {
+    std::cout << "Manually seeding" << std::endl;
     unsigned char buf[256];
     unsigned int seed = (unsigned)time(NULL) ^ (unsigned)getpid();
     unsigned int v = seed;

--- a/src/libSchnorr/src/SeedPRNG.cpp
+++ b/src/libSchnorr/src/SeedPRNG.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <openssl/rand.h>
+#include "SchnorrInternal.h"
+
+bool SeedPRNG() {
+  unsigned int attempt = 0;
+  while ((RAND_status() == 0) && (attempt++ < 10)) {
+    unsigned char buf[256];
+    unsigned int seed = (unsigned)time(NULL) ^ (unsigned)getpid();
+    unsigned int v = seed;
+    for (unsigned int i = 0; i < 256 / sizeof(v); i++) {
+      memmove(buf + i * sizeof(v), &v, sizeof(v));
+      v = v * seed + (unsigned int)i;
+    }
+    RAND_seed(buf, 256);
+  }
+  return RAND_status() != 0;
+}


### PR DESCRIPTION
**References:**
https://www.openssl.org/docs/man1.0.2/man3/RAND_add.html
https://cpp.hotexamples.com/examples/-/-/RAND_seed/cpp-rand_seed-function-examples.html

**Changes:**
1. Added new function `SeedPRNG`, which will explicitly do `RAND_seed` if and until `RAND_status` is non-zero
2. Called `SeedPRNG` inside `PrivKey` constructor
3. Fixed license checker to ignore copyright date

**Testing:**
Since `RAND_status` normally returns 1 already, tweak this line and run the unit tests:

From:
```
while ((RAND_status() == 0) && (attempt++ < 10)) {
```
To:
```
while ((RAND_status() == 1) && (attempt++ < 10)) {
```