### PR TITLE
Fix security vulnerability related to memset

### DIFF
--- a/src/libSchnorr/src/generate_dsa_nonce.c
+++ b/src/libSchnorr/src/generate_dsa_nonce.c
@@ -52,6 +52,17 @@
 extern "C" {
 #endif
 
+void *memset_secured(void *dest, size_t dest_sz, int c, size_t count) {
+  if (count > dest_sz) {
+    count = dest_sz;
+  }
+  volatile unsigned char *p = dest;
+  while (count--) {
+    *p++ = (unsigned char)c;
+  }
+  return dest;
+}
+
 int BN_generate_dsa_nonce(BIGNUM *out, const BIGNUM *range,
                           const BIGNUM *priv, const unsigned char *message,
                           size_t message_len, BN_CTX *ctx)
@@ -87,7 +98,7 @@ int BN_generate_dsa_nonce(BIGNUM *out, const BIGNUM *range,
         goto err;
     }
     memcpy(private_bytes, priv->d, todo);
-    memset(private_bytes + todo, 0, sizeof(private_bytes) - todo);
+    memset_secured(private_bytes + todo, sizeof(private_bytes), 0, sizeof(private_bytes) - todo);
 
     for (done = 0; done < num_k_bytes;) {
         //FIXME: RAND_priv_bytes replaced with RAND_bytes(), see the difference:

--- a/src/libSchnorr/src/generate_dsa_nonce.h
+++ b/src/libSchnorr/src/generate_dsa_nonce.h
@@ -33,6 +33,8 @@ extern "C" {
 int BN_generate_dsa_nonce(BIGNUM *out, const BIGNUM *range, const BIGNUM *priv,
                           const unsigned char *message, size_t message_len,
                           BN_CTX *ctx);
+void *memset_secured(void *dest, size_t dest_sz, int c, size_t count);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Description
The goal of the PR is to address the security vulnerability related to memset usage in Schnorr library code.The memset call can be optimized out by compiler for the buffer which eventually be deleted and could cause no effect.
Alternative is to use `memset_s`(C++11 annex K), `explicit_bzero`(free BSD) or provide own implementation.
We are going with our own implementation for this.

## Testing
Local testing on Ubuntu 16 machine by running local testnet.
Devnet test on Ubuntu16 docker image.

## Test Results
Test is successful and block explorer showing normal epoch progress.

Note: The code will only applicable for platforms where `openssl` version is less than `1.1` .for eg ubuntu 16 -`1.0.2g`.