### PR TITLE
Revert BN_nnmod changes

### DIFF
--- a/src/libSchnorr/src/MultiSig.cpp
+++ b/src/libSchnorr/src/MultiSig.cpp
@@ -367,7 +367,7 @@ bool MultiSig::MultiSigVerify(const bytes& message, unsigned int offset,
         return false;
       }
       err2 = (BN_nnmod(challenge_built.get(), challenge_built.get(),
-                       Schnorr::GetCurveOrder(), ctx.get()) == 0);
+                       Schnorr::GetCurveOrder(), NULL) == 0);
       err = err || err2;
       if (err2) {
         // Challenge rebuild mod failed

--- a/src/libSchnorr/src/MultiSig_Challenge.cpp
+++ b/src/libSchnorr/src/MultiSig_Challenge.cpp
@@ -129,11 +129,6 @@ void Challenge::Set(const CommitPoint& aggregatedCommit,
 
   bytes buf(Schnorr::PUBKEY_COMPRESSED_SIZE_BYTES);
 
-  unique_ptr<BN_CTX, void (*)(BN_CTX*)> ctx(BN_CTX_new(), BN_CTX_free);
-  if (!ctx) {
-    throw std::bad_alloc();
-  }
-
   // Convert the committment to octets first
   if (EC_POINT_point2oct(Schnorr::GetCurveGroup(), aggregatedCommit.m_p.get(),
                          POINT_CONVERSION_COMPRESSED, buf.data(),
@@ -171,8 +166,7 @@ void Challenge::Set(const CommitPoint& aggregatedCommit,
     return;
   }
 
-  if (BN_nnmod(m_c.get(), m_c.get(), Schnorr::GetCurveOrder(), ctx.get()) ==
-      0) {
+  if (BN_nnmod(m_c.get(), m_c.get(), Schnorr::GetCurveOrder(), NULL) == 0) {
     // Could not reduce challenge modulo group order
     return;
   }

--- a/src/libSchnorr/src/MultiSig_CommitPointHash.cpp
+++ b/src/libSchnorr/src/MultiSig_CommitPointHash.cpp
@@ -104,10 +104,6 @@ void CommitPointHash::Set(const CommitPoint& point) {
   // byte to 0x01.
   sha2.Update({SECOND_DOMAIN_SEPARATED_HASH_FUNCTION_BYTE});
 
-  unique_ptr<BN_CTX, void (*)(BN_CTX*)> ctx(BN_CTX_new(), BN_CTX_free);
-  if (!ctx) {
-    throw std::bad_alloc();
-  }
   // Convert the commitment to octets first
   if (EC_POINT_point2oct(Schnorr::GetCurveGroup(), point.m_p.get(),
                          POINT_CONVERSION_COMPRESSED, buf.data(),
@@ -127,8 +123,7 @@ void CommitPointHash::Set(const CommitPoint& point) {
     return;
   }
 
-  if (BN_nnmod(m_h.get(), m_h.get(), Schnorr::GetCurveOrder(), ctx.get()) ==
-      0) {
+  if (BN_nnmod(m_h.get(), m_h.get(), Schnorr::GetCurveOrder(), NULL) == 0) {
     // Could not reduce hashpoint value modulo group order
     return;
   }


### PR DESCRIPTION
This PR reverts the `BN_nnmod` changes done in PR #4 
The changes were needed for Ubuntu 20 only, and seem to incur some performance penalty
We will stay at Ubuntu 18 for the foreseeable future