### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ install(
 )
 
 install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/src/libSchnorr/include
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/libSchnorr/include
     DESTINATION ${CMAKE_INSTALL_PREFIX}
     USE_SOURCE_PERMISSIONS
 )


### PR DESCRIPTION
installing headers. This allows installing from projects that use this as a submodule.