### PR TITLE
Add vcpkg generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,8 @@ compile_commands.json
 .idea
 .vscode
 .history
+
+# vcpkg
+vcpkg-registry/
+vcpkg-configuration.json
+vcpkg.json


### PR DESCRIPTION
The files generated by `vcpkg` is creating noise in the scilla repo, so I've added them to `.gitignore` here.
